### PR TITLE
Remove reaction by replace console.log for message containing "42"

### DIFF
--- a/src/Events/messages.ts
+++ b/src/Events/messages.ts
@@ -3,6 +3,6 @@ import { Event } from "../structures/Event";
 export default new Event("messageCreate", async (message) => {
   if (message.author.bot) return;
   if (message.content.includes("42")) {
-    message.react("👍");
+    console.log("42 include in message : ", message.content);
   }
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "DOM"],
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "ESNext",


### PR DESCRIPTION
We get bot reactions too often for messages talking about 42 or people mentioning someone whose ID contains the number 42.