### PR TITLE
fix(env): removing hard coded part (for mdb) and change the token field for env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,4 +5,3 @@ uid42=string
 mdbmdp=string
 mdbuser=string
 mdblink=string
-mdbname=string

--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,8 @@
-Token=string
+botToken=string
 logchannel=int
 secret42=string
 uid42=string
 mdbmdp=string
 mdbuser=string
+mdblink=string
+mdbname=string

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import ClientOAuth2 from "client-oauth2";
 export const client = new ExtendedClient();
 
 const { MongoClient, ServerApiVersion } = require("mongodb");
-const uri = `mongodb+srv://${process.env.mdbuser}:${process.env.mdbmdp}@bot-42.qxgaebq.mongodb.net/?retryWrites=true&w=majority`;
+const uri = `mongodb+srv://${process.env.mdbuser}:${process.env.mdbmdp}@${process.env.mdblink}/?retryWrites=true&w=majority`;
 
 export const clientdb = new MongoClient(uri, {
   serverApi: {


### PR DESCRIPTION
This pull request includes updates to environment variable naming and database connection configuration to improve clarity and flexibility. The most important changes involve renaming an environment variable and updating the MongoDB connection string to use the new variable.

### Environment variable updates:
* [`.env.sample`](diffhunk://#diff-088d9f35d23a4347d221d71dd49b02b95001dff4abe637a40fe0bc04d502049cL1-R7): Renamed `Token` to `botToken` for better clarity and added a new `mdblink` variable to specify the MongoDB cluster link.

### Database connection configuration:
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L8-R8): Updated the MongoDB connection URI to use the new `mdblink` environment variable, improving flexibility for different database cluster configurations.